### PR TITLE
React 16 support

### DIFF
--- a/__tests__/visibility-toggles-test.js
+++ b/__tests__/visibility-toggles-test.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import VisibilityToggles from '../src';
 
 describe('VisibilityToggles', function () {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "url": "https://github.com/reactabular/react-visibility-toggles/issues"
   },
   "homepage": "https://reactabular.github.io/react-visibility-toggles/",
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.6.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
@@ -64,16 +66,15 @@
     "gh-pages": "^0.12.0",
     "git-prepush-hook": "^1.0.1",
     "jest": "^17.0.3",
-    "react": "^15.4.1",
-    "react-addons-test-utils": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-styleguidist": "^4.4.1",
     "rimraf": "^2.5.4",
     "webpack": "^1.14.0",
     "webpack-merge": "^1.0.2"
   },
   "peerDependencies": {
-    "react": ">= 15.0.0 < 16.0.0"
+    "react": ">= 15.0.0 < 17.0.0"
   },
   "pre-push": [
     "test:all"

--- a/src/visibility-toggles.js
+++ b/src/visibility-toggles.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types, no-unused-vars */
 // XXX: The prop type checking bugs out for some reason partially.
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const VisibilityToggles = ({
   columns,
@@ -65,17 +66,17 @@ VisibilityToggles.propTypes = {
    *   }
    * \]
    */
-  columns: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  onToggleColumn: React.PropTypes.func,
-  isVisible: React.PropTypes.func,
+  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onToggleColumn: PropTypes.func,
+  isVisible: PropTypes.func,
   /**
    * Props attached to different parts of the component.
    */
-  props: React.PropTypes.shape({
-    container: React.PropTypes.object,
-    label: React.PropTypes.object,
-    value: React.PropTypes.object,
-    toggle: React.PropTypes.object
+  props: PropTypes.shape({
+    container: PropTypes.object,
+    label: PropTypes.object,
+    value: PropTypes.object,
+    toggle: PropTypes.object
   })
 };
 VisibilityToggles.defaultProps = {


### PR DESCRIPTION
- Update peer dependencies to include React 16.
- Import PropTypes from prop-types package.